### PR TITLE
Prefer int math when constructing DateTime from milliseconds

### DIFF
--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -223,11 +223,9 @@ static PHP_METHOD(MongoDB_BSON_UTCDateTime, toDateTime)
 	object_init_ex(return_value, php_date_get_date_ce());
 	datetime_obj = Z_PHPDATE_P(return_value);
 
-	sec_len = spprintf(&sec, 0, "@%" PRId64, intern->milliseconds / 1000);
+	sec_len = spprintf(&sec, 0, "@%.6f", (double) intern->milliseconds / 1000);
 	php_date_initialize(datetime_obj, sec, sec_len, NULL, NULL, 0);
 	efree(sec);
-
-	datetime_obj->time->us = (intern->milliseconds % 1000) * 1000;
 }
 
 static PHP_METHOD(MongoDB_BSON_UTCDateTime, jsonSerialize)

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -223,7 +223,10 @@ static PHP_METHOD(MongoDB_BSON_UTCDateTime, toDateTime)
 	object_init_ex(return_value, php_date_get_date_ce());
 	datetime_obj = Z_PHPDATE_P(return_value);
 
-	sec_len = spprintf(&sec, 0, "@%.6f", (double) intern->milliseconds / 1000);
+	/* Initialize a DateTime using "Unix Timestamp with microseconds" notation.
+	 * PHP 7.4 expects exactly six points of precision to denote microseconds.
+	 * PHP 8.0+ accepts between zero and six points of precision. */
+	sec_len = spprintf(&sec, 0, "@%" PRId64 ".%.6d", intern->milliseconds / 1000, abs((int) (intern->milliseconds % 1000) * 1000));
 	php_date_initialize(datetime_obj, sec, sec_len, NULL, NULL, 0);
 	efree(sec);
 }

--- a/tests/bson/bson-utcdatetime-todatetime-003.phpt
+++ b/tests/bson/bson-utcdatetime-todatetime-003.phpt
@@ -1,0 +1,22 @@
+--TEST--
+MongoDB\BSON\UTCDateTime::toDateTime() with dates before the Unix epoch
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+
+$date = new \DateTimeImmutable('1960-01-01 12:12:12.1');
+echo $date->format('Y-m-d H:i:s.u'), PHP_EOL;
+
+$utcdatetime = new MongoDB\BSON\UTCDateTime($date);
+
+$newDate = $utcdatetime->toDateTime();
+echo $newDate->format('Y-m-d H:i:s.u'), PHP_EOL;
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+1960-01-01 12:12:12.100000
+1960-01-01 12:12:12.100000
+===DONE===


### PR DESCRIPTION
The "Unix Timestamp with microseconds" notation was introduced in php/php-src@55626549d81d0feadb1d160be78fcf2b898a48cc and originally expected exactly six points of precision. The format was relaxed in php/php-src@0bc8785b615e908a74461df2568ba9b906f3f5c0 for PHP 8.0+ to accept between zero and six points of precision.